### PR TITLE
added temporary ignore file

### DIFF
--- a/kinetic.ignored
+++ b/kinetic.ignored
@@ -1,0 +1,2 @@
+cob_bringup
+cob_robots


### PR DESCRIPTION
This should allow us to ignore cob_bringup temporarily for proceeding with the first kinetic release. We will remove the ignore file afterwards and create another release.
@ipa-fxm we placed the file in the wrong repository, it belongs to the release repo.