### PR TITLE
removed temporary ignore file

### DIFF
--- a/kinetic.ignored
+++ b/kinetic.ignored
@@ -1,2 +1,0 @@
-cob_bringup
-cob_robots


### PR DESCRIPTION
Reverts ignoring cob_bringup package now that we have an initial release.